### PR TITLE
Fix dahdi-freebsd for FreeBSD 13.0

### DIFF
--- a/drivers/dahdi/dahdi-base.c
+++ b/drivers/dahdi/dahdi-base.c
@@ -104,6 +104,7 @@
 #define chan_to_netdev(h) ((h)->hdlcnetdev->netdev)
 
 #if defined(__FreeBSD__)
+#include <sys/eventhandler.h>
 #include <sys/filio.h>
 #include <sys/proc.h>
 

--- a/drivers/dahdi/voicebus/GpakApi.c
+++ b/drivers/dahdi/voicebus/GpakApi.c
@@ -1560,7 +1560,7 @@ gpakReadDSPMemoryStat_t gpakReadDSPMemoryMap(
     if (DspStatus != 0)
         return (RmmFailure);
 
-	for (i = 0; i < MemoryLength_Word16; i++)
+    for (i = 0; i < MemoryLength_Word16; i++)
         pDest[i] = (short int) MsgBuffer[2 + i];
 
 

--- a/include/linux/crc32.h
+++ b/include/linux/crc32.h
@@ -1,6 +1,9 @@
 #ifndef _LINUX_CRC32_H_
 #define _LINUX_CRC32_H_
 
+#if defined(__FreeBSD__)
+#include <sys/gsb_crc32.h>
+#endif
 #include <sys/libkern.h>
 
 #define crc32_le(crc, data, len)	crc32_raw(data, len, crc)


### PR DESCRIPTION
The attached 3 changes will make this compile for FreeBSD 13.0.

As you're the port maintainer, would you mind pushing these into the tree? The kmods are currently marked as broken.

References:
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=252907
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=253386